### PR TITLE
Add option to run joiner for RGB-only imagery

### DIFF
--- a/.idea/csv-editor.xml
+++ b/.idea/csv-editor.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CsvFileAttributes">
+    <option name="attributeMap">
+      <map>
+        <entry key="\sample_files\1\ExifLog.csv">
+          <value>
+            <Attribute>
+              <option name="separator" value="," />
+            </Attribute>
+          </value>
+        </entry>
+      </map>
+    </option>
+  </component>
+</project>

--- a/gui/__main__.py
+++ b/gui/__main__.py
@@ -67,6 +67,10 @@ class JoinDataForm(QtWidgets.QWidget):
         return str(self.combo_coord_type.currentText())
 
     @property
+    def rgb_imagery(self):
+        return self.radio_rgb.isChecked()
+
+    @property
     def orthometric_heights(self):
         return self.radio_orthometric.isChecked()
 
@@ -107,14 +111,15 @@ class JoinDataForm(QtWidgets.QWidget):
 
     @property
     def joiner(self):
+        out_suffix = "_cal.tif" if self.rgb_imagery else "_rgbi.tif"
         if self.coord_type == "UTM" and self.orthometric_heights:
-            return UTMOrthoRenamer()
+            return UTMOrthoRenamer(out_suffix=out_suffix)
         elif self.coord_type == "UTM":
-            return UTMEllipsRenamer()
+            return UTMEllipsRenamer(out_suffix=out_suffix)
         elif self.coord_type == "Geographic" and self.orthometric_heights:
-            return GeographicOrthoRenamer()
+            return GeographicOrthoRenamer(out_suffix=out_suffix)
         elif self.coord_type == "Geographic":
-            return GeographicEllipsRenamer()
+            return GeographicEllipsRenamer(out_suffix=out_suffix)
         else:
             raise RuntimeError("coord_type error")
 

--- a/gui/resources/gui.ui
+++ b/gui/resources/gui.ui
@@ -187,6 +187,51 @@
     </widget>
    </item>
    <item>
+    <widget class="QWidget" name="widget" native="true">
+     <layout class="QVBoxLayout" name="verticalLayout_5">
+      <item>
+       <widget class="QLabel" name="label_4">
+        <property name="text">
+         <string>Imagery Type</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QWidget" name="widget_8" native="true">
+        <property name="layoutDirection">
+         <enum>Qt::LeftToRight</enum>
+        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout_5">
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QRadioButton" name="radio_cir">
+           <property name="text">
+            <string>4-band CIR</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QRadioButton" name="radio_rgb">
+           <property name="text">
+            <string>Distortion Corrected RGB</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="QFrame" name="frame">
      <property name="frameShape">
       <enum>QFrame::StyledPanel</enum>

--- a/join_eos_exif/OrthoRenamer.py
+++ b/join_eos_exif/OrthoRenamer.py
@@ -9,8 +9,9 @@ logger = logging.getLogger(__name__)
 
 
 class OrthoRenamer(ABC):
-    def __init__(self, verbose=True):
+    def __init__(self, out_suffix="_rgbi.tif", verbose=True):
         super().__init__()
+        self.out_suffix = out_suffix
         self.verbose = verbose
         self.errors = []  # list of filenames that can not be matched.
 
@@ -91,7 +92,7 @@ class OrthoRenamer(ABC):
         joined = pd.merge(eos, exif, left_on="# EVENT", right_on="GPS Event")
 
         # Create updated filename column
-        joined["CIR_Filename"] = joined["Filename"].str[:-4] + "_rgbi.tif"
+        joined["CIR_Filename"] = joined["Filename"].str.replace(".IIQ", self.out_suffix)
 
         # Populate the errors list
         unmatched_exif = exif[(~exif["Filename"].isin(joined["Filename"]))]


### PR DESCRIPTION
Our NIR camera is currently down, and the ortho imagery processing pipeline doesn't handle it well. This PR adds a feature that effectively allows specifying the output filename suffix, such that importing the joined files into metashape can be made to run correctly. 

The GUI provides an option to use RGB only imagery instead of 4-band CIRs via a radio toggle.